### PR TITLE
Child process exec options, fixes maxBuffer size problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,30 @@ Shows the current version number.
 
 Write reporting result to the path
 
-#### `-b, --buffersize <path>`
+#### `-b, --buffersize <size>`
 
 Increase [maxBuffer](https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_exec_command_options_callback) size to prevent #3, `!!! OUTPUT ERROR` or `Unexpected end of JSON input` errors. This is because [child_process stdout being truncated](https://github.com/nodejs/node/issues/19218) when validator check a lot of files.
+
+##### CLI `-b, --buffersize`
+
+```bash
+# increase buffer size (1024 * 500)
+node-w3c-validator -i static/**/*.html -b 500
+```
+
+##### CLI `exec.bufferSize`
+
+```js
+// increase buffer size (1024 * 500)
+nodeW3CValidator(validatePath, {
+    format: 'html',
+    exec: {
+        bufferSize: 1024 * 500
+    }
+}, function (err, output) {
+    // ...
+});
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Shows the current version number.
 
 Write reporting result to the path
 
+#### `-b, --buffersize <path>`
+
+Increase [maxBuffer](https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_exec_command_options_callback) size to prevent #3, `!!! OUTPUT ERROR` or `Unexpected end of JSON input` errors. This is because [child_process stdout being truncated](https://github.com/nodejs/node/issues/19218) when validator check a lot of files.
+
 ---
 
 ## Node.js API

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Increase [maxBuffer](https://nodejs.org/docs/latest-v10.x/api/child_process.html
 node-w3c-validator -i static/**/*.html -b 500
 ```
 
-##### CLI `exec.bufferSize`
+##### Node.js API `exec.bufferSize`
 
 ```js
 // increase buffer size (1024 * 500)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -31,6 +31,7 @@ program
 	.option('--no-stream', 'Forces all documents to be be parsed in buffered mode instead of streaming mode (causes some parse errors to be treated as non-fatal document errors instead of as fatal document errors)')
 	.option('-v, --verbose', 'Specifies "verbose" output (currently this just means that the names of files being checked are written to stdout)')
 	.option('-o, --output [path]', 'Write reporting result to the path')
+	.option('-b, --buffersize <size>', '1024 * <size> Increase maxBuffer size for child_process.exec, if result output truncated')
 	.parse(process.argv);
 
 /**
@@ -47,7 +48,8 @@ const cliProps = [
 	'skipNonHtml',
 	'html',
 	'stream',
-	'verbose'
+	'verbose',
+	'buffersize'
 ];
 
 /**
@@ -59,7 +61,8 @@ const cliProps = [
 function detectUserOptions () {
 	let outputPath = program.output;
 	let userOptions = {
-		output: false
+		output: false,
+		exec: {}
 	};
 
 	cliProps.forEach(prop => {
@@ -70,6 +73,10 @@ function detectUserOptions () {
 		}
 		if (value !== undefined) {
 			userOptions[prop] = value;
+
+			if (prop === 'buffersize') {
+				userOptions.exec.maxBuffer = 1024 * value;
+			}
 		}
 	});
 	if (typeof outputPath === 'string' && outputPath.length) {

--- a/lib/render-html.js
+++ b/lib/render-html.js
@@ -73,7 +73,7 @@ function renderHtml (jsonString) {
 			console.log('Try increase maxBuffer size with:');
 			console.log(` ${chalk.gray('-')} CLI --buffersize <size> (1024 * <size>)`);
 			console.log(` ${chalk.gray('-')} NodeJs API options.exec.maxBuffer 1024 * <size>`);
-			console.log(`${chalk.yellow('Readme:')} https://github.com/dutchenkoOleg/node-w3c-validator#-b---buffersize-path`);
+			console.log(`${chalk.yellow('Readme:')} https://github.com/dutchenkoOleg/node-w3c-validator#-b---buffersize-size`);
 			console.log('');
 		}
 		process.exit(1);

--- a/lib/render-html.js
+++ b/lib/render-html.js
@@ -60,11 +60,23 @@ function renderHtml (jsonString) {
 		let msg = JSON.parse(jsonString).messages;
 		messages = msg;
 	} catch (e) {
-		console.log(chalk.red('!!! OUTPUT ERROR'));
+		console.log('');
+		console.log(e.message);
+
 		if (e.message === 'Unexpected token E in JSON at position 1') {
 			console.log(chalk.red('Possible cause of error - incorrect path or files were not found'));
 		}
-		return e.message;
+
+		if (e.message === 'Unexpected end of JSON input') {
+			console.log(chalk.red('Possible cause of error'));
+			console.log('NodeJS maxBuffer to small for your task because child_process stdout being truncated.');
+			console.log('Try increase maxBuffer size with:');
+			console.log(` ${chalk.gray('-')} CLI --buffersize <size> (1024 * <size>)`);
+			console.log(` ${chalk.gray('-')} NodeJs API options.exec.maxBuffer 1024 * <size>`);
+			console.log(`${chalk.yellow('Readme:')} https://github.com/dutchenkoOleg/node-w3c-validator#-b---buffersize-path`);
+			console.log('');
+		}
+		process.exit(1);
 	}
 
 	if (!messages.length) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -127,6 +127,10 @@ function getArgvFromObject (options) {
 		argv.push(`--filterpattern  ${options.filterpattern}`);
 	}
 
+	if (options.buffersize) {
+		argv.push(`--buffersize ${options.buffersize}`);
+	}
+
 	booleanArgs.forEach(key => {
 		if (options[key]) {
 			argv.push(`--${camel2dash(key)}`);
@@ -152,7 +156,7 @@ function nodeW3CValidator (validationPath, userOptions, done) {
 	let execPath = [vnuCmd].concat(getArgvFromObject(options), fileset.sync(validationPath));
 
 	// console.log(execPath.join(' '));
-	exec(execPath.join(' '), function (err, stdout, stderr) {
+	exec(execPath.join(' '), options.exec, function (err, stdout, stderr) {
 		let output = stdout;
 
 		if (err === null) {


### PR DESCRIPTION
This PR closes #3 and closes #7.

Increase [maxBuffer](https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_exec_command_options_callback) size to prevent #3, `!!! OUTPUT ERROR` or `Unexpected end of JSON input` errors. This is because [child_process stdout being truncated](https://github.com/nodejs/node/issues/19218) when validator check a lot of files.

| Version | maxBuffer | Documentation link |
| ------------- | ------------- | ------------- |
| 8.x LTS  | 200 * 1024  | [child_process.exec(command[, options][, callback])](https://nodejs.org/docs/latest-v8.x/api/child_process.html#child_process_child_process_exec_command_options_callback) |
| 10.x LTS  | 200 * 1024  | [child_process.exec(command[, options][, callback])](https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_exec_command_options_callback) |
| 12.x  | 1024 * 1024  | [child_process.exec(command[, options][, callback])](https://nodejs.org/docs/latest-v12.x/api/child_process.html#child_process_child_process_exec_command_options_callback) |