### PR TITLE
test: add functional test suite (node:test) for CLI and Node.js API

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,11 +33,5 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test CLI HTML
-        run: npm run cli-html
-
-      - name: Test CLI Lint
-        run: npm run cli-lint
-
-      - name: Test NodeJS Api
-        run: npm run nodejs-api
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "npm run lint",
+    "test": "node --test tests/*.test.js",
     "cli-html": "node ./bin/cmd.js -i ./tests/html/valid-examples/*.html -f html -o ./results/cli-api-report.html",
     "cli-lint": "node ./bin/cmd.js -i ./tests/html/valid-examples/*.html -f lint",
     "nodejs-api": "node ./tests/demo.js"

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Functional tests for the Node.js API (lib/validator.js) — callback contract
+// -----------------------------------------------------------------------------
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { hasJava, fixture } = require('./helpers');
+const nodeW3CValidator = require('../lib/validator');
+
+const skip = hasJava ? false : 'Java runtime is not available';
+
+test('reports err === null for a valid document', { skip }, (t, done) => {
+	nodeW3CValidator(fixture('pass.html'), { format: 'json' }, (err) => {
+		assert.strictEqual(err, null);
+		done();
+	});
+});
+
+test('reports an error and JSON output for an invalid document', { skip }, (t, done) => {
+	nodeW3CValidator(fixture('fail.html'), { format: 'json' }, (err, output) => {
+		assert.notStrictEqual(err, null);
+		const report = JSON.parse(output);
+		assert.ok(report.messages.length > 0);
+		done();
+	});
+});
+
+test('writeFile (sync) creates the file with the given contents', () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
+	const filePath = path.join(dir, 'nested', 'out.txt');
+	try {
+		nodeW3CValidator.writeFile(filePath, 'hello');
+		assert.strictEqual(fs.readFileSync(filePath, 'utf8'), 'hello');
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+// Bug B: writeFile's async branch calls `mkdirp(dir, cb)`, but mkdirp@1 removed
+// the callback API, so it throws "invalid options argument" synchronously.
+// Kept as TODO until Phase 3 replaces mkdirp with fs.mkdir({ recursive: true }).
+test('writeFile (async) creates the file and invokes the callback', { todo: 'Bug B: mkdirp@1 has no callback API' }, (t, done) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
+	const filePath = path.join(dir, 'nested', 'out.txt');
+	nodeW3CValidator.writeFile(filePath, 'hello', (err) => {
+		try {
+			assert.ifError(err);
+			assert.strictEqual(fs.readFileSync(filePath, 'utf8'), 'hello');
+			done();
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Functional tests for the CLI (bin/cmd.js) — black-box, drives the real binary
+// -----------------------------------------------------------------------------
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { hasJava, fixture, runCli } = require('./helpers');
+
+const skip = hasJava ? false : 'Java runtime is not available';
+
+test('valid document exits 0 (lint format)', { skip }, async () => {
+	const { code } = await runCli(['-i', fixture('pass.html'), '-f', 'lint']);
+	assert.strictEqual(code, 0);
+});
+
+test('invalid document exits 1 and reports the errors (lint)', { skip }, async () => {
+	const { code, stdout } = await runCli(['-i', fixture('fail.html'), '-f', 'lint']);
+	assert.strictEqual(code, 1);
+	assert.match(stdout, /not allowed/);
+	assert.match(stdout, /missing a required instance/);
+	assert.match(stdout, /alt/);
+});
+
+test('invalid document exits 1 and prints a report (json)', { skip }, async () => {
+	const { code, stdout } = await runCli(['-i', fixture('fail.html'), '-f', 'json']);
+	assert.strictEqual(code, 1);
+	assert.match(stdout, /FOUND ERRORS/);
+	assert.match(stdout, /"messages"/);
+});
+
+test('writes a valid JSON report to the -o output path', { skip }, async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
+	const outPath = path.join(dir, 'report.json');
+	try {
+		const { code } = await runCli([
+			'-i', fixture('fail.html'),
+			'-f', 'json',
+			'-o', outPath
+		]);
+		assert.strictEqual(code, 1);
+		assert.ok(fs.existsSync(outPath), 'report file should exist');
+		const report = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+		assert.ok(report.messages.length > 0);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('suppressErrors from package.json drops matching errors', { skip }, async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
+	const pkg = {
+		name: 'suppress-fixture',
+		nodeW3Cvalidator: {
+			suppressErrors: ['is missing a required instance of child element']
+		}
+	};
+	fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+	try {
+		// one-error.html's only problem is the suppressed one → exit 0
+		const { code } = await runCli(
+			['-i', fixture('one-error.html'), '-f', 'json'],
+			{ cwd: dir }
+		);
+		assert.strictEqual(code, 0);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+// -----------------------------------------------------------------------------
+// Known pre-existing bugs — kept as TODO so they stay visible without failing
+// CI. Scheduled to be fixed in Phase 3, after which the `todo` flag is removed.
+// -----------------------------------------------------------------------------
+
+// Bug A: the Java-availability check does `JSON.parse(stderr)`, which throws for
+// any non-JSON output (gnu/text/xml, and the default no-format run), so the CLI
+// wrongly reports "you haven't installed Java" and exits 1.
+test('valid document exits 0 with the default format', { skip, todo: 'Bug A: Java-detection misfires on non-JSON output' }, async () => {
+	const { code } = await runCli(['-i', fixture('pass.html')]);
+	assert.strictEqual(code, 0);
+});
+
+test('gnu format output references the validated file', { skip, todo: 'Bug A: Java-detection misfires on non-JSON output' }, async () => {
+	const { stdout } = await runCli(['-i', fixture('fail.html'), '-f', 'gnu']);
+	assert.match(stdout, /fail\.html/);
+});

--- a/tests/fixtures/fail.html
+++ b/tests/fixtures/fail.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+	<foo></foo>
+	<img src="x">
+</body>
+</html>

--- a/tests/fixtures/one-error.html
+++ b/tests/fixtures/one-error.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+</head>
+<body>
+	<h1>Hi</h1>
+</body>
+</html>

--- a/tests/fixtures/pass.html
+++ b/tests/fixtures/pass.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Valid document</title>
+</head>
+<body>
+	<h1>Hello world</h1>
+</body>
+</html>

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Shared test helpers
+// -----------------------------------------------------------------------------
+
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const binPath = path.join(__dirname, '..', 'bin', 'cmd.js');
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+/**
+ * Whether a Java runtime is available. The validator shells out to
+ * `java -jar vnu.jar`, so the functional suites are skipped without it.
+ * @const {boolean}
+ */
+const hasJava = spawnSync('java', ['-version']).error === undefined;
+
+/**
+ * Absolute path to a fixture file
+ * @param {string} name
+ * @returns {string}
+ */
+function fixture (name) {
+	return path.join(fixturesDir, name);
+}
+
+/**
+ * Run the CLI (bin/cmd.js) as a child process and collect its result.
+ * @param {Array.<string>} args
+ * @param {Object} [options]
+ * @param {string} [options.cwd]
+ * @returns {Promise.<{code: number, stdout: string, stderr: string}>}
+ */
+function runCli (args, options = {}) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [binPath, ...args], {
+			cwd: options.cwd || process.cwd(),
+			env: { ...process.env, FORCE_COLOR: '0' }
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout.on('data', (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += chunk;
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+}
+
+module.exports = {
+	binPath,
+	fixturesDir,
+	hasJava,
+	fixture,
+	runCli
+};


### PR DESCRIPTION
Replace the linter-only `npm test` with real black-box functional tests that drive the actual CLI binary and the programmatic API against HTML fixtures. No production code is touched — tests exercise behaviour, not internals, so they survive the Phase 3 refactor.

- tests/cli.test.js: exit codes, lint/json output, -o file writing, suppressErrors via package.json config
- tests/api.test.js: nodeW3CValidator callback contract, writeFile
- tests/helpers.js: runCli() child-process runner, Java guard (suites skip cleanly when no JVM is present)
- package.json: test -> `node --test tests/*.test.js`
- CI: replace manual cli-html/cli-lint/nodejs-api steps with `npm test`

The suite surfaced two pre-existing bugs, captured as TODO tests so they stay visible without failing CI (to be fixed in Phase 3):
- Bug A: Java-availability check JSON.parse(stderr) misfires for non-JSON formats (gnu/text/xml and the default no-format run) -> false "Java not installed" error and exit 1
- Bug B: writeFile async branch calls mkdirp(dir, cb) but mkdirp@1 dropped the callback API -> throws "invalid options argument"

Result: 8 pass, 0 fail, 3 todo; `npm test` exits 0.