### PR TITLE
refactor: harden exec, fix bugs A/B, modernize deps

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -6,7 +6,7 @@
 
 const path = require('path');
 const chalk = require('chalk');
-const program = require('commander');
+const { program } = require('commander');
 const pkg = require('../package.json');
 const nodeW3CValidator = require('../lib/validator');
 
@@ -80,6 +80,13 @@ program
 	.parse(process.argv);
 
 /**
+ * Parsed CLI options (commander 7+ exposes them via `program.opts()`)
+ * @const {Object}
+ * @private
+ */
+const cliOptions = program.opts();
+
+/**
  * Properties list for auto detecting
  * @const {Array.<string>}
  * @private
@@ -104,16 +111,16 @@ const cliProps = [
  * @sourceCode
  */
 function detectUserOptions () {
-	let outputPath = program.output;
+	let outputPath = cliOptions.output;
 	let userOptions = {
 		output: false,
 		exec: {},
-		filterfile: program.filterfile,
-		filterpattern: program.filterpattern
+		filterfile: cliOptions.filterfile,
+		filterpattern: cliOptions.filterpattern
 	};
 
 	cliProps.forEach((prop) => {
-		let value = program[prop];
+		let value = cliOptions[prop];
 
 		if ((prop === 'stream' || prop === 'langdetect') && value) {
 			return;
@@ -137,7 +144,7 @@ function detectUserOptions () {
  * @returns {*}
  */
 function detectUserInput () {
-	let validatePath = program.input;
+	let validatePath = cliOptions.input;
 
 	if (typeof validatePath !== 'string') {
 		validatePath = process.cwd();
@@ -153,8 +160,8 @@ function detectUserInput () {
 
 const userOptions = detectUserOptions();
 const validatePath = detectUserInput();
-if (program.exclude) {
-	userOptions.exclude = program.exclude;
+if (cliOptions.exclude) {
+	userOptions.exclude = cliOptions.exclude;
 }
 
 // ----------------------------------------

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -13,11 +13,9 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const mkdirp = require('mkdirp');
 const fileset = require('fileset');
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 const vnuJar = require('vnu-jar');
-const _ = require('lodash');
 const ora = require('ora');
 
 const pkg = require('../package.json');
@@ -30,12 +28,13 @@ const lintFormat = require('./lint-format');
 // ----------------------------------------
 
 /**
- * vnu command
- * @const {string}
+ * JVM + vnu-jar invocation arguments, passed to `java` via execFile.
+ * Kept as an array so every argument is a separate argv token (no shell).
+ * @const {Array.<string>}
  * @private
  * @sourceCode
  */
-const vnuCmd = `java -Xss2048k -jar ${vnuJar}`;
+const jvmArgs = ['-Xss2048k', '-jar', vnuJar];
 
 /**
  * List of command line arguments without value
@@ -77,7 +76,7 @@ function camel2dash (str) {
  * @sourceCode
  */
 function getOptions (userOptions = {}) {
-	let options = _.cloneDeep(userOptions);
+	let options = structuredClone(userOptions);
 
 	if (options.format === 'html') {
 		options.outputAsHtml = true;
@@ -104,11 +103,11 @@ function getArgvFromObject (options) {
 	let format = options.format;
 
 	if (formatList.get(format)) {
-		argv.push(`--format ${format}`);
+		argv.push('--format', format);
 	}
 
 	if (options.asciiquotes) {
-		argv.push('--asciiquotes yes');
+		argv.push('--asciiquotes', 'yes');
 	}
 
 	if (options.stream === false) {
@@ -120,15 +119,15 @@ function getArgvFromObject (options) {
 	}
 
 	if (options.filterfile) {
-		argv.push(`--filterfile ${options.filterfile}`);
+		argv.push('--filterfile', options.filterfile);
 	}
 
 	if (options.filterpattern) {
-		argv.push(`--filterpattern ${options.filterpattern}`);
+		argv.push('--filterpattern', options.filterpattern);
 	}
 
 	if (options.buffersize) {
-		argv.push(`--buffersize ${options.buffersize}`);
+		argv.push('--buffersize', String(options.buffersize));
 	}
 
 	booleanArgs.forEach((key) => {
@@ -203,10 +202,22 @@ function nodeW3CValidator (validationPath, userOptions, done) {
 		delete userOptions.exclude;
 	}
 	let options = getOptions(userOptions);
-	let execPath = [vnuCmd].concat(getArgvFromObject(options), fileset.sync(validationPath, exclude));
+	let args = jvmArgs.concat(getArgvFromObject(options), fileset.sync(validationPath, exclude));
 
-	// console.log(execPath.join(' '));
-	exec(execPath.join(' '), options.exec, function (err, stdout, stderr) {
+	execFile('java', args, options.exec, function (err, stdout, stderr) {
+		// `err.code === 'ENOENT'` means the `java` binary itself was not found.
+		// A non-zero vnu exit (validation errors) gives a numeric err.code, so
+		// this reliably distinguishes "Java missing" from "errors found" for
+		// every output format.
+		if (err && err.code === 'ENOENT') {
+			spinner.fail(`${pkg.name} - unexpected error`);
+			console.log(chalk.red('ERROR:'), 'An unexpected error has occurred');
+			console.log('It looks like you haven\'t installed Java');
+			console.log('- https://github.com/dutchenkoOleg/node-w3c-validator#attention');
+			console.log('- https://java.com');
+			process.exit(1);
+		}
+
 		let output = stderr;
 
 		if (options.format === 'json' && err) {
@@ -216,18 +227,6 @@ function nodeW3CValidator (validationPath, userOptions, done) {
 			} else {
 				output = newOutput;
 			}
-		}
-
-		// Test for Java Installed
-		try {
-			JSON.parse(stderr); // JSON string with empty "messages"
-		} catch {
-			console.log('\n');
-			console.log(chalk.red('ERROR:'), 'An unexpected error has occurred');
-			console.log('It looks like you haven\'t installed Java');
-			console.log('- https://github.com/dutchenkoOleg/node-w3c-validator#attention');
-			console.log('- https://java.com');
-			process.exit(1);
 		}
 
 		if (err === null) {
@@ -264,14 +263,15 @@ nodeW3CValidator.writeFile = function (filePath, outputData, done) {
 	let dir = path.dirname(filePath);
 
 	if (typeof done === 'function') {
-		mkdirp(dir, (err) => {
+		fs.mkdir(dir, { recursive: true }, (err) => {
 			if (err) {
-				throw new Error(err);
+				done(err);
+				return;
 			}
 			fs.writeFile(filePath, outputData, done);
 		});
 	} else {
-		mkdirp.sync(dir);
+		fs.mkdirSync(dir, { recursive: true });
 		fs.writeFileSync(filePath, outputData);
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
-        "commander": "^6.2.0",
+        "commander": "^12.1.0",
         "eslint-formatter-pretty": "^4.0.0",
         "fileset": "^2.0.3",
         "lodash": ">=4.17.20",
-        "mkdirp": "^1.0.4",
         "ora": "^5.1.0",
         "vnu-jar": "^26.8.6"
       },
@@ -683,11 +682,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -1372,17 +1372,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -2195,9 +2184,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2692,11 +2681,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,10 @@
   ],
   "dependencies": {
     "chalk": "^4.1.0",
-    "commander": "^6.2.0",
+    "commander": "^12.1.0",
     "eslint-formatter-pretty": "^4.0.0",
     "fileset": "^2.0.3",
     "lodash": ">=4.17.20",
-    "mkdirp": "^1.0.4",
     "ora": "^5.1.0",
     "vnu-jar": "^26.8.6"
   },

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -42,10 +42,10 @@ test('writeFile (sync) creates the file with the given contents', () => {
 	}
 });
 
-// Bug B: writeFile's async branch calls `mkdirp(dir, cb)`, but mkdirp@1 removed
-// the callback API, so it throws "invalid options argument" synchronously.
-// Kept as TODO until Phase 3 replaces mkdirp with fs.mkdir({ recursive: true }).
-test('writeFile (async) creates the file and invokes the callback', { todo: 'Bug B: mkdirp@1 has no callback API' }, (t, done) => {
+// Regression coverage for Bug B: writeFile's async branch used mkdirp(dir, cb),
+// but mkdirp@1 dropped the callback API and threw synchronously. Phase 3
+// replaced it with fs.mkdir(dir, { recursive: true }).
+test('writeFile (async) creates the file and invokes the callback', (t, done) => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
 	const filePath = path.join(dir, 'nested', 'out.txt');
 	nodeW3CValidator.writeFile(filePath, 'hello', (err) => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -52,6 +52,24 @@ test('writes a valid JSON report to the -o output path', { skip }, async () => {
 	}
 });
 
+test('html format writes a full HTML report to -o', { skip }, async () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
+	const outPath = path.join(dir, 'report.html');
+	try {
+		const { code } = await runCli([
+			'-i', fixture('fail.html'),
+			'-f', 'html',
+			'-o', outPath
+		]);
+		assert.strictEqual(code, 1);
+		const html = fs.readFileSync(outPath, 'utf8');
+		assert.match(html, /<!doctype html>/i);
+		assert.match(html, /node-w3c-validator/);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test('suppressErrors from package.json drops matching errors', { skip }, async () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nw3c-'));
 	const pkg = {
@@ -74,19 +92,18 @@ test('suppressErrors from package.json drops matching errors', { skip }, async (
 });
 
 // -----------------------------------------------------------------------------
-// Known pre-existing bugs — kept as TODO so they stay visible without failing
-// CI. Scheduled to be fixed in Phase 3, after which the `todo` flag is removed.
+// Non-JSON output formats — regression coverage for Bug A (Java-availability
+// check used to JSON.parse(stderr) and misfire for gnu/text/xml and the
+// default no-format run). Fixed in Phase 3 via execFile ENOENT detection.
 // -----------------------------------------------------------------------------
 
-// Bug A: the Java-availability check does `JSON.parse(stderr)`, which throws for
-// any non-JSON output (gnu/text/xml, and the default no-format run), so the CLI
-// wrongly reports "you haven't installed Java" and exits 1.
-test('valid document exits 0 with the default format', { skip, todo: 'Bug A: Java-detection misfires on non-JSON output' }, async () => {
+test('valid document exits 0 with the default format', { skip }, async () => {
 	const { code } = await runCli(['-i', fixture('pass.html')]);
 	assert.strictEqual(code, 0);
 });
 
-test('gnu format output references the validated file', { skip, todo: 'Bug A: Java-detection misfires on non-JSON output' }, async () => {
-	const { stdout } = await runCli(['-i', fixture('fail.html'), '-f', 'gnu']);
+test('gnu format output references the validated file', { skip }, async () => {
+	const { code, stdout } = await runCli(['-i', fixture('fail.html'), '-f', 'gnu']);
+	assert.strictEqual(code, 1);
 	assert.match(stdout, /fail\.html/);
 });


### PR DESCRIPTION
Security & correctness pass over the validator core. All existing functional tests stay green and the two TODO regressions now pass.

- exec -> execFile: build the `java` invocation as an argv array instead of a shell string. No shell means file paths, --filterpattern and --filterfile can no longer be interpreted as shell syntax (command injection fix). getArgvFromObject now emits separate argv tokens.
- Fix Bug A: detect a missing Java runtime via execFile's ENOENT error instead of JSON.parse(stderr). The old check misfired for every non-JSON format (gnu/text/xml and the default no-format run), which wrongly reported "Java not installed" and exited 1.
- Fix Bug B: writeFile async now uses fs.mkdir(dir, { recursive: true }); drop mkdirp (its v1 removed the callback API and threw).
- Drop lodash from validator.js: cloneDeep -> structuredClone.
- commander 6 -> 12: read options via program.opts(), import { program }.
- tests: add an -f html report smoke test.